### PR TITLE
Add PRIMAVERA mip_era

### DIFF
--- a/Tables/CMIP6_CV.json
+++ b/Tables/CMIP6_CV.json
@@ -1705,7 +1705,8 @@
             "^CMIP6 model data produced by .* is licensed under a Creative Commons Attribution.*ShareAlike 4.0 International License (https://creativecommons.org/licenses)\\. Consult https://pcmdi.llnl.gov/CMIP6/TermsOfUse for terms of use governing CMIP6 output, including citation requirements and proper acknowledgment\\. Further information about this data, including some limitations, can be found via the further_info_url (recorded as a global attribute in this file) .*\\. The data producers and data providers make no warranty, either express or implied, including, but not limited to, warranties of merchantability and fitness for a particular purpose\\. All liabilities arising from the supply of the information (including any liability arising in negligence) are excluded to the fullest extent permitted by law\\.$"
         ],
         "mip_era":[
-            "CMIP6"
+            "CMIP6",
+            "PRIMAVERA"
         ],
         "sub_experiment_id":{
             "none":"none",


### PR DESCRIPTION
At one of the updates the PRIMAVERA mip_era was lost from the controlled vocabulary. This re-adds it.